### PR TITLE
Consider inst in fake? and return early

### DIFF
--- a/src/amplitude/util.cljs
+++ b/src/amplitude/util.cljs
@@ -11,6 +11,7 @@
 
 (defn fake? [thing]
   (cond
+    (inst? thing)    false
     (boolean? thing) false
     (int? thing)     false
     (nil? thing)     true


### PR DESCRIPTION
Else remove-nils can fail since inst are not seqs