### PR TITLE
docs: remove undefined call

### DIFF
--- a/README.org
+++ b/README.org
@@ -293,7 +293,6 @@ flows using cognito
 
 #+BEGIN_SRC clojure
 (:require [amplitude.auth :as auth])
-(auth/init!)
 (auth/sign-in {:username xxx :password xxx})
 (auth/sign-out)
 #+END_SRC


### PR DESCRIPTION
I removed the `(auth/init!)` call from the README as there is no `init!` function in `amplitude.auth`.